### PR TITLE
Add <cstdio> header for file dma.h

### DIFF
--- a/dvi/dma.cpp
+++ b/dvi/dma.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "dvi.h"
+#include <cstdio>
 
 namespace dvi
 {

--- a/dvi/dma.h
+++ b/dvi/dma.h
@@ -13,6 +13,7 @@
 #include <stdint.h>
 #include <array>
 #include <utility>
+#include <cstdio>
 
 namespace dvi
 {

--- a/dvi/dma.h
+++ b/dvi/dma.h
@@ -13,7 +13,6 @@
 #include <stdint.h>
 #include <array>
 #include <utility>
-#include <cstdio>
 
 namespace dvi
 {


### PR DESCRIPTION
Hi,

I upgraded my dev environment to Ubuntu 24.04 LTS. This comes whith arm-none-eabi-gcc 13.2.1.

When building pico_lib i noticed there is a compiler error in pico_lib/dvi/dma.cpp, which did not occur in previous versions of gcc:

/home/frank/projects/public/pico-infones/pico_lib/dvi/dma.cpp: In constructor 'dvi::DMA::DMA(const dvi::Timing&, PIO)':
/home/frank/projects/public/pico-infones/pico_lib/dvi/dma.cpp:57:13: error: 'printf' was not declared in this scope
   57 |             printf("lane %d: DMA ch ctrl %d, ch data %d, FIFO %p, dreq %d\n", i, cfg.chCtrl, cfg.chData, cfg.txFIFO, cfg.dreq);
      |             ^~~~~~
/home/frank/projects/public/pico-infones/pico_lib/dvi/dma.cpp:7:1: note: 'printf' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?

So i added 

#include <cstdio> to pico_lib/dvi/dma.h

which solved the error.


Best regards,

Frank