### PR TITLE
Development

### DIFF
--- a/dvi/dvi.cpp
+++ b/dvi/dvi.cpp
@@ -31,7 +31,7 @@ namespace dvi
         assert(pio_);
         assert(config_);
         assert(timing_);
-
+       
         initSerialiser();
         allocateBuffers(timing);
 
@@ -296,6 +296,12 @@ namespace dvi
     void
     DVI::initSerialiser()
     {
+        // Adjust PIO for gpio pins > 32
+        // The Waveshare RP2350-PiZero is a board that is using gpio pins > 32.
+        if (config_->pinTMDS[0] > 32 || config_->pinTMDS[1] > 32 || config_->pinTMDS[2] > 32)
+        {
+            pio_set_gpio_base(pio_, 16);
+        }
         auto configurePad = [](int gpio, bool invert)
         {
             hw_write_masked(

--- a/dvi/dvi.cpp
+++ b/dvi/dvi.cpp
@@ -456,6 +456,14 @@ namespace dvi
     }
 
     void
+    DVI::convertScanBuffer12bpp(uint16_t line, uint16_t *buffer, size_t size)
+    {
+        auto dstTMDS = freeTMDSQueue_.deque();
+        encodeTMDS_RGB444(dstTMDS->data(), buffer, size);
+        validTMDSQueue_.enque({line, dstTMDS});
+    }
+
+    void
     DVI::convertScanBuffer12bppScaled16_7(int srcPixelOfs, int dstPixelOfs, int dstPixels)
     {
         auto dstTMDS = freeTMDSQueue_.deque();
@@ -473,6 +481,24 @@ namespace dvi
         validTMDSQueue_.enque({srcLine.line, dstTMDS});
         freeLineQueue_.enque(std::move(srcLine.buffer));
     }
+
+    void
+    DVI::convertScanBuffer12bppScaled16_7(int srcPixelOfs, int dstPixelOfs, int dstPixels, uint16_t line, uint16_t *buffer, size_t size)
+    {
+        auto dstTMDS = freeTMDSQueue_.deque();
+
+        srcPixelOfs &= ~1u;
+        dstPixelOfs &= ~1u;
+
+        auto *p = dstTMDS->data() + (dstPixelOfs >> 1);
+        encodeTMDS_RGB444_Scaled16_7(p,
+                                     buffer + srcPixelOfs,
+                                     dstPixels,
+                                     size);
+
+        validTMDSQueue_.enque({line, dstTMDS});
+    }
+
 
     void
     DVI::setAudioFreq(int freq, int CTS, int N)

--- a/dvi/dvi.h
+++ b/dvi/dvi.h
@@ -37,8 +37,9 @@ namespace dvi
 
         void __not_in_flash_func(convertScanBuffer15bpp)();
         void __not_in_flash_func(convertScanBuffer12bpp)();
+        void __not_in_flash_func(convertScanBuffer12bpp)(uint16_t line, uint16_t *buffer, size_t size);
         void __not_in_flash_func(convertScanBuffer12bppScaled16_7)(int srcPixelOfs, int dstPixelOfs, int dstPixels);
-
+        void __not_in_flash_func(convertScanBuffer12bppScaled16_7)(int srcPixelOfs, int dstPixelOfs, int dstPixels, uint16_t line, uint16_t *buffer, size_t size);
         uint32_t getFrameCounter() const
         {
             return frameCounter_;

--- a/dvi/dvi_serialiser.pio
+++ b/dvi/dvi_serialiser.pio
@@ -15,8 +15,10 @@ namespace dvi
 
 inline void serialiserProgramInit(PIO pio, uint sm, uint offset, uint data_pins, uint nWords)
 {
-    pio_sm_set_pins_with_mask(pio, sm, 2u << data_pins, 3u << data_pins);
-    pio_sm_set_pindirs_with_mask(pio, sm, ~0u, 3u << data_pins);
+    // pio_sm_set_pins_with_mask(pio, sm, 2u << data_pins, 3u << data_pins);
+    // pio_sm_set_pindirs_with_mask(pio, sm, ~0u, 3u << data_pins);
+    pio_sm_set_pins_with_mask64(pio, sm, 2ULL << data_pins, 3ULL << data_pins);
+    pio_sm_set_pindirs_with_mask64(pio, sm, ~0ULL, 3ULL << data_pins);
     pio_gpio_init(pio, data_pins);
     pio_gpio_init(pio, data_pins + 1);
 

--- a/dvi/timing.cpp
+++ b/dvi/timing.cpp
@@ -5,7 +5,9 @@
 
 #include "timing.h"
 #include <pico.h>
-
+#ifndef CPUKFREQKHZ
+#define CPUKFREQKHZ 252000
+#endif
 namespace dvi
 {
     namespace
@@ -23,7 +25,7 @@ namespace dvi
             .vBackPorch = 33,
             .vActiveLines = 480,
 
-            .bitClockKHz = 252000,
+            .bitClockKHz = CPUKFREQKHZ,
         };
     }
 

--- a/dvi/tmds_encode.S
+++ b/dvi/tmds_encode.S
@@ -1,3 +1,4 @@
+#include "pico.h"
 #include "hardware/regs/addressmap.h"
 #include "hardware/regs/sio.h"
 #include "dvi_config_defs.h"


### PR DESCRIPTION
Hi,

I made some changes in pico_lib. Hope you don't mind.

- Added convertScanBuffer12bpp & convertScanBuffer12bppScaled16_7,  which takes a WORD buffer to render. This makes it possible to use a 320x240 2byte framebuffer on RP2350.  Maybe it has to be implemented differently, but it works. It eliminates the red screen flicker when the screen cannot be updated in time because of SD card IO. I will release this in my version of the emulator within a few days. Has a lot of changes in supported boards and even shows boxart.
- Refactor serialiserProgramInit to use 64-bit mask functions for pin configuration, which makes it possible to use gpio pins > 32 for hdmi boards.
- Adjust PIO base for GPIO pins greater than 32 in initSerialiser
- Fix compiler error in Pico SDK 2.2.0


When approved, I will create a pull request for the emulator itself later on.
